### PR TITLE
Support for price per quarter

### DIFF
--- a/MMM-Nordpool.js
+++ b/MMM-Nordpool.js
@@ -14,6 +14,7 @@ Module.register("MMM-Nordpool", {
 			pointColor: "white",
 			currentPointColor: "red",
 		},
+		useHourlyAverage: false,
 	},
 	chartCanvasId: "nordpool_chart_canvas",
 	chartRedrawTimeoutId: null,
@@ -32,6 +33,7 @@ Module.register("MMM-Nordpool", {
 				area: this.config.area,
 				currency: this.config.currency,
 				date: (new Date()).toISOString(),
+				useHourlyAverage: this.config.useHourlyAverage,
 			}
 		);
 		this.scheduleNordpoolUpdate();
@@ -49,7 +51,7 @@ Module.register("MMM-Nordpool", {
 			now.getMonth(),
 			now.getDate()+1,
 			this.config.updateNordpoolHour,
-			Math.floor(Math.random() * this.config.maxRandomUpdateMinute),
+			Math.floor(Math.random() * this.config.maxRandomUpdateMinute)
 		);
 		const msTillNext = (tomorrow - now) + 1000; // lets do it 1s after midnight
 		let self = this;
@@ -64,8 +66,15 @@ Module.register("MMM-Nordpool", {
 		}
 
 		const now = new Date();
-		const nextHour = new Date(now.getFullYear(),now.getMonth(),now.getDate(), now.getHours() + 1);
-		const msTillNext = (nextHour - now) + 1000; // lets do it 1s after new hour
+		const nextQuarter = now.getMinutes() >= 45 ? 60
+			: now.getMinutes() >= 30 ? 45
+				: now.getMinutes() >= 15 ? 30
+					: now.getMinutes() >= 0 ? 15 : 0
+
+		const nextTick = this.config.useHourlyAverage ?
+			new Date(now.getFullYear(),now.getMonth(),now.getDate(), now.getHours() + 1)
+			: new Date(now.getFullYear(),now.getMonth(),now.getDate(), now.getHours(), nextQuarter);
+		const msTillNext = (nextTick - now) + 1000; // lets do it 1s after new hour
 		let self = this;
 		this.chartRedrawTimeoutId = setTimeout(function() {
 			self.updateChart();
@@ -118,7 +127,12 @@ Module.register("MMM-Nordpool", {
 		const config = this.config.chartConfig;
 
 		const module = this;
-		const currentHour = (new Date()).getHours().toString().padStart(2, "0").concat(":00");
+		const now = new Date();
+		const currentHour = now.getHours().toString().padStart(2, "0");
+		const currentQuarter = this.config.useHourlyAverage ? 0
+			: now.getMinutes() >= 45 ? 45
+				: now.getMinutes() >= 30 ? 30
+					: now.getMinutes() >= 15 ? 15 : 0
 
 		const dataset = {
 			label: this.config.currency + "/MWh",
@@ -127,7 +141,7 @@ Module.register("MMM-Nordpool", {
 				const index = context.dataIndex;
 				const itemHour = module.dataResponse.hours[index];
 
-				if (currentHour === itemHour) {
+				if (currentHour.concat(":", currentQuarter.toString().padStart(2, "0")) === itemHour) {
 					return config.currentPointColor;
 				} else {
 					return config.pointColor;

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ var config = {
 
 | Option    | Description                                                                                                     |
 |-----------|-----------------------------------------------------------------------------------------------------------------|
-| `area` | Area of interest<br><br>**Type:** `string` allowed values: `Bergen`, `DK1`, `DK2`, `FI`, `Kr.sand`, `Molde`, `OSLO`, `SE1`, `SE2`, `SE3`, `SE4`, `SYS`, `Tr.heim`, `Tromsø'`, `EE`, `LV`, `LT`, `AT`, `BE`, `DE-LU`, `FR`,  `NL` . More details [here](https://www.npmjs.com/package/nordpool#options)<br>**Default:** `LV`                                                                             |
-| `currency` | Currency to use, minor units (cents) will be displayed <br><br>**Type:** `string` allowed values: `DKK`, `EUR`, `NOK`, `SEK`. More details [here](https://www.npmjs.com/package/nordpool#options)<br>**Default:** `EUR` |
-| `updateNordpoolHour` | When to pull data for next day in your local time. See known issues<br><br>**Type:** `int` allowed values: `0-23`. More details [here](https://www.npmjs.com/package/nordpool#options)<br>**Default:** `1` |
-| `maxRandomUpdateMinute` | This randomizes minute when the data is pulled. Poor attempt to not to accidentally DDoS Nordpool, lol<br><br>**Type:** `int` Suggested `0-60` More details [here](https://www.npmjs.com/package/nordpool#options)<br>**Default:** `15` |
-| `chartConfig` | Customisation options for the chart, see [Chart.js docs](https://www.chartjs.org/docs/latest/general/options.html#dataset-level-options) for inspiration. Only exceptions are `currentPointColor` and `pointColor` those are introduced by this module, overriding `pointBackgroundColor` will make them useless<br><br>**Type:** `object` More details [here](https://www.chartjs.org/docs/latest/general/options.html#dataset-level-options)<br>**Default:**  *see full config example* |
+| `area` | Area of interest<br><br>**Type:** `string`. <br>**Default:** `LV`|
+| `currency` | Currency to use, minor units (cents) will be displayed <br><br>**Type:** `string` <br>**Default:** `EUR` |
+| `updateNordpoolHour` | When to pull data for next day in your local time. See known issues<br><br>**Type:** `int` allowed values: `0-23`.<br>**Default:** `1` |
+| `maxRandomUpdateMinute` | This randomizes minute when the data is pulled. Poor attempt to not to accidentally DDoS Nordpool, lol<br><br>**Type:** `int` Suggested `0-60`<br>**Default:** `15` |
+| `chartConfig` | Customisation options for the chart, see [Chart.js docs](https://www.chartjs.org/docs/2.9.4/configuration/) for inspiration. Only exceptions are `currentPointColor` and `pointColor` those are introduced by this module, overriding `pointBackgroundColor` will make them useless<br><br>**Type:** `object` More details [here](https://www.chartjs.org/docs/2.9.4/configuration/)<br>**Default:**  *see full config example* |
 | `useHourlyAverage` |When true uses 60 minute resolution. When false - 15 minutes <br><br>**Type:** `bool`<br>**Default:**  `false` |
 
 ## Full config example
@@ -74,7 +74,7 @@ var config = {
 ```
 
 ## Known issues
-- Nordpool returns data based on `Europe/Oslo` timezone, from 00:00 to 23:00, that's why there is `updateNordpoolHour` config option, for my use case data starts at 01:00 which does not bother me enough to fix that. If it bothers you - PRs are more welcome ❤️
+- Nordpool returns data based on `Europe/Oslo` timezone, from 00:00 to 23:00, that's why there is `updateNordpoolHour` config option, for my use case data starts at 01:00 which does not bother me enough to fix that. If it bothers you - PRs are more than welcome ❤️
 
 ## Useful resources
 - [Nordpool](https://www.nordpoolgroup.com/en/ "Nordpool")

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 This is a module for the [MagicMirror²](https://github.com/MichMich/MagicMirror/).
 
-Shows chart of hourly electricity prices on Nordpool market for current day.
+Shows chart of electricity prices on Nordpool market for current day.
 
-Relies on unofficial [Nordpool client](https://www.npmjs.com/package/nordpool "Nordpool client").
 Before using this module get familiar with [Nordpool Terms and conditions for use of website](https://www.nordpoolgroup.com/en/About-us/terms-and-conditions-for-useofwebsite/ "Nordpool Terms and conditions for use of website").
 
 ![](https://raw.githubusercontent.com/DanielsSt/MMM-Nordpool/master/screenshots/screenshot.png)
@@ -43,6 +42,7 @@ var config = {
 | `updateNordpoolHour` | When to pull data for next day in your local time. See known issues<br><br>**Type:** `int` allowed values: `0-23`. More details [here](https://www.npmjs.com/package/nordpool#options)<br>**Default:** `1` |
 | `maxRandomUpdateMinute` | This randomizes minute when the data is pulled. Poor attempt to not to accidentally DDoS Nordpool, lol<br><br>**Type:** `int` Suggested `0-60` More details [here](https://www.npmjs.com/package/nordpool#options)<br>**Default:** `15` |
 | `chartConfig` | Customisation options for the chart, see [Chart.js docs](https://www.chartjs.org/docs/latest/general/options.html#dataset-level-options) for inspiration. Only exceptions are `currentPointColor` and `pointColor` those are introduced by this module, overriding `pointBackgroundColor` will make them useless<br><br>**Type:** `object` More details [here](https://www.chartjs.org/docs/latest/general/options.html#dataset-level-options)<br>**Default:**  *see full config example* |
+| `useHourlyAverage` |When true uses 60 minute resolution. When false - 15 minutes <br><br>**Type:** `bool`<br>**Default:**  `false` |
 
 ## Full config example
 
@@ -65,7 +65,8 @@ var config = {
                     pointBorderColor: "black",
                     pointColor: "white",
                     currentPointColor: "red",
-                }
+                },
+                useHourlyAverage: false
             }
         }
     ]

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,42 +1,51 @@
 var NodeHelper = require("node_helper");
-const {Prices} = require("nordpool");
+const dayjs = require("dayjs");
+const axios = require("axios");
 
 module.exports = NodeHelper.create({
 
 	socketNotificationReceived: async function(notification, payload) {
 		if (notification === "MMM-Nordpool-get-data") {
-			const results = await this.getHourlyConsumerPrices(payload.area, payload.currency, payload.date);
-			this.sendSocketNotification("MMM-Nordpool-get-data", results);
+			this.getHourlyConsumerPrices(payload.area, payload.currency, payload.date, payload.useHourlyAverage);
 		}
 	},
 
-	getHourlyConsumerPrices: async function (area, currency, date) {
-
-		const opts = {
-			area: area.toUpperCase(),
-			currency: currency.toUpperCase(),
-			date: date,
-		};
-
+	getHourlyConsumerPrices: async function (area, currency, date, useHourlyAverage) {
 		const prettyResults = {prices: [], hours: [], avgPrice: 0};
 		let pricesSum = 0;
+        const module = this;
+        axios.get("https://dataportal-api.nordpoolgroup.com/api/DayAheadPriceIndices?".concat(
+            "date=",  dayjs(date).format("YYYY-MM-DD"),
+            "&market=DayAhead",
+            "&indexNames=", area.toUpperCase(),
+            "&currency=", currency.toUpperCase(),
+            "&resolutionInMinutes=", (useHourlyAverage ? 60 : 15).toString(),
+        )).then(function(response) {
+            if (response.status === 200) {
+                let results = response.data.multiIndexEntries;
+                for (const item of results) {
+                    const date = new Date(item.deliveryStart);
+                    const hour = date.getHours()
+                        .toString()
+                        .padStart(2, '0')
+                        .concat(':' + date.getMinutes().toString().padStart(2, '0'));
+                    const price = Math.round(item.entryPerArea[area.toUpperCase()] * 100) / 1000
 
-		const prices = new Prices();
-		const results = await prices.hourly(opts);
+                    console.log(`${hour}\t${price.toFixed(3)} ${currency}/kWh`)
 
-		for (const item of results) {
-			const date = new Date(item.date)
-			const hour = date.getHours().toString().padStart(2, '0').concat(':00')
-			const price = Math.round(item.value * 100) / 1000
+                    prettyResults.prices.push(price);
+                    prettyResults.hours.push(hour);
+                    pricesSum += price;
+                }
+                prettyResults.avgPrice = (pricesSum / results.length).toFixed(3);
 
-			console.log(`${hour}\t${price.toFixed(3)} ${currency}/kWh`)
-
-			prettyResults.prices.push(price);
-			prettyResults.hours.push(hour);
-			pricesSum += price;
-		}
-
-		prettyResults.avgPrice = (pricesSum / results.length).toFixed(3);
-		return prettyResults;
+                module.sendSocketNotification("MMM-Nordpool-get-data", prettyResults);
+            } else {
+                console.log("Could not load data.", "ERROR_FAILED_DL", response.status);
+            }
+        }).catch(function (error) {
+            console.log("Could not load data!", "ERROR_FAILED_DL", {message: error.message, stack: error.stack});
+            throw error;
+        });
 	},
 });

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "time-grunt": "latest"
   },
   "dependencies": {
-    "dayjs": "^1.11.10",
-    "nordpool": "file:libs/nordpool-node"
-  },
-  "scripts": {
-    "preinstall": "(mkdir libs || (rm -rf libs && mkdir libs)) && cd libs && git clone https://github.com/samuelmr/nordpool-node.git && cd nordpool-node && git checkout f9e3a34fc4c00e16995868cdf1f6871fbbae80a7 && npm run build"
+    "axios": "^1.12.2",
+    "dayjs": "^1.11.10"
   }
 }


### PR DESCRIPTION
- Introduced new config option `useHourlyAverage`
  - Set to true if your provider still uses hourly average instead of quarter, false by default
- Got rid of Nordpool lib, something I should have done a while back
- Updated readme 